### PR TITLE
CMP-580 - Fixed accessibility of ctor of ContentItemUpdateModel

### DIFF
--- a/KenticoCloud.ContentManagement/Models/Items/ContentItemUpdateModel.cs
+++ b/KenticoCloud.ContentManagement/Models/Items/ContentItemUpdateModel.cs
@@ -22,11 +22,11 @@ namespace KenticoCloud.ContentManagement.Models.Items
         [JsonProperty("sitemap_locations", Required = Required.Always)]
         public IEnumerable<SitemapNodeIdentifier> SitemapLocations { get; set; } = Enumerable.Empty<SitemapNodeIdentifier>();
 
-        internal ContentItemUpdateModel()
+        public ContentItemUpdateModel()
         {
         }
 
-        internal ContentItemUpdateModel(ContentItemModel contentItem)
+        public ContentItemUpdateModel(ContentItemModel contentItem)
         {
             Name = contentItem.Name;
             SitemapLocations = contentItem.SitemapLocations.Select(s => SitemapNodeIdentifier.ById(s.Id));


### PR DESCRIPTION
Constructors of ContentItemUpdateModel were internal therefore it was unable to use this model based on the docs.