### PR TITLE
Unify methods of resolving app's base folder among repos

### DIFF
--- a/KenticoCloud.ContentManagement.Tests/ContentManagementClientTests.cs
+++ b/KenticoCloud.ContentManagement.Tests/ContentManagementClientTests.cs
@@ -1084,7 +1084,7 @@ namespace KenticoCloud.ContentManagement.Tests
             var descriptions = new List<AssetDescription>();
             var title = "My new asset";
 
-            var filePath = Path.Combine(AppContext.BaseDirectory, "Data\\kentico_rgb_bigger.png");
+            var filePath = Path.Combine(Environment.CurrentDirectory, "Data\\kentico_rgb_bigger.png");
             var contentType = "image/png";
 
             var assetResult = await client.CreateAssetAsync(new FileContentSource(filePath, contentType), new AssetUpdateModel { Descriptions = descriptions, Title = title });

--- a/KenticoCloud.ContentManagement.Tests/Mocks/FileSystemHttpClientMock.cs
+++ b/KenticoCloud.ContentManagement.Tests/Mocks/FileSystemHttpClientMock.cs
@@ -118,7 +118,7 @@ namespace KenticoCloud.ContentManagement.Tests.Mocks
 
         private string GetMockFileFolder(HttpRequestMessage message, string hashContent)
         {
-            var rootPath = Path.Combine(AppContext.BaseDirectory, "Data\\");
+            var rootPath = Path.Combine(Environment.CurrentDirectory, "Data\\");
             var testPath = Path.Combine(rootPath, _directoryName);
             var stringMessageHash = GetHashFingerprint(hashContent);
 


### PR DESCRIPTION
The [AppContext.BaseDirectory](https://github.com/mellinoe/ge/issues/2) might return other than the project's root folder. Retrieving of test assets might fail.

Make the code aligned with https://github.com/Kentico/delivery-sdk-net/commit/aa62e70f4e00cff1bebcaebd68c994913a78c3d7#diff-8282cff8647d4e2e2fc87e28e571c6a7 .