### PR TITLE
Issue 29 fix

### DIFF
--- a/KenticoCloud.ContentManagement.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
+++ b/KenticoCloud.ContentManagement.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using KenticoCloud.ContentManagement.Models.Items;
+using KenticoCloud.ContentManagement.Modules.ActionInvoker;
+using KenticoCloud.ContentManagement.Modules.HttpClient;
+
+using Xunit;
+
+namespace KenticoCloud.ContentManagement.Tests
+{
+    internal class FakeContentManagementHttpClient : IContentManagementHttpClient {
+        internal string requestBody;
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message) {
+            requestBody = await message.Content.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
+        }
+    }
+
+    public class ActionInvokerTests
+    {
+        [Fact]
+        [Trait("Issue", "29")]
+        public void ActionInvokerSerializeElementContainingZero_SerializedJsonContainsZero() {
+            var httpClient = new FakeContentManagementHttpClient();
+            var actionInvoker = new ActionInvoker(httpClient, new MessageCreator("{api_key}"));
+            
+            var contentItemVariantUpsertModel = new ContentItemVariantUpsertModel() {
+                Elements = new {
+                    number = new decimal(0),
+                },
+            };
+
+            var result = actionInvoker.InvokeMethodAsync<ContentItemVariantUpsertModel, dynamic>("{endpoint_url}", HttpMethod.Get,contentItemVariantUpsertModel);
+            Assert.Equal("{\"elements\":{\"number\":0}}", httpClient.requestBody);
+        }
+    }
+}

--- a/KenticoCloud.ContentManagement.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
+++ b/KenticoCloud.ContentManagement.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
@@ -31,12 +31,13 @@ namespace KenticoCloud.ContentManagement.Tests
             
             var contentItemVariantUpsertModel = new ContentItemVariantUpsertModel() {
                 Elements = new {
-                    number = new decimal(0),
+                    zero = new decimal(0),
+                    optZero = new decimal?(0),
                 },
             };
 
             var result = actionInvoker.InvokeMethodAsync<ContentItemVariantUpsertModel, dynamic>("{endpoint_url}", HttpMethod.Get,contentItemVariantUpsertModel);
-            Assert.Equal("{\"elements\":{\"number\":0}}", httpClient.requestBody);
+            Assert.Equal("{\"elements\":{\"zero\":0,\"optZero\":0}}", httpClient.requestBody);
         }
     }
 }

--- a/KenticoCloud.ContentManagement/Modules/ActionInvoker/ActionInvoker.cs
+++ b/KenticoCloud.ContentManagement/Modules/ActionInvoker/ActionInvoker.cs
@@ -19,11 +19,12 @@ namespace KenticoCloud.ContentManagement.Modules.ActionInvoker
 
         private JsonSerializerSettings _serializeSettings = new JsonSerializerSettings {
             NullValueHandling = NullValueHandling.Ignore,
+            Converters = new List<JsonConverter> { new DecimalObjectConverter() },
         };
 
         private JsonSerializerSettings _deserializeSettings = new JsonSerializerSettings
         {
-            Converters = new List<JsonConverter> { new DynamicObjectJsonConverter() }
+            Converters = new List<JsonConverter> { new DynamicObjectJsonConverter() },
         };
 
 

--- a/KenticoCloud.ContentManagement/Modules/ActionInvoker/DecimalObjectConverter.cs
+++ b/KenticoCloud.ContentManagement/Modules/ActionInvoker/DecimalObjectConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KenticoCloud.ContentManagement.Modules.ActionInvoker
+{
+    internal class DecimalObjectConverter : JsonConverter {
+
+        public override bool CanConvert(Type objectType) 
+            => objectType == typeof(decimal) || objectType == typeof(decimal?);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            => throw new NotImplementedException($"{nameof(DecimalObjectConverter)} class should be only used for serialization.");
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) 
+        {
+            switch (value)
+            {
+            case decimal dec when dec == 0:
+                // Serialize decimal(0) to 0 instead of 0.0
+                // NOTE: See issue #29
+                JToken.FromObject(0).WriteTo(writer);
+                break;
+            default:
+                JToken.FromObject(value).WriteTo(writer);
+                break;
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Motivation

`DecimalObjectConverter` was created and used in `_serializeSettings` of `ActionInvoker` to create workaround for API not being able to accept decimal `0.0`.

Fixes #29

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Should be covered with automated test.