### PR TITLE
DEL-2063 - Allow slashes in external ids

### DIFF
--- a/KenticoCloud.ContentManagement.Tests/EndpointUrlBuilderTests.cs
+++ b/KenticoCloud.ContentManagement.Tests/EndpointUrlBuilderTests.cs
@@ -17,7 +17,8 @@ namespace KenticoCloud.ContentManagement.Tests
 
         private static Guid ITEM_ID = Guid.Parse("b444004b-a4c4-43e3-94e0-d5bbd49d6cb8");
         private const string ITEM_CODENAME = "{ITEM_CODENAME}";
-        private const string ITEM_EXTERNAL_ID = "{ITEM_EXTERNAL_ID}";
+        private const string ITEM_EXTERNAL_ID = "{ITEM_EXT/ERNAL_ID}";
+        private const string EXPECTED_ITEM_EXTERNAL_ID = "%7BITEM_EXT%2FERNAL_ID%7D";
 
         private static Guid VARIANT_ID = Guid.Parse("5a64af00-a98d-4d2e-adb6-45120cbc0242");
         private const string VARIANT_CODENAME = "{VARIANT_CODENAME}";
@@ -110,7 +111,7 @@ namespace KenticoCloud.ContentManagement.Tests
             var variantIdentifier = LanguageIdentifier.ById(VARIANT_ID);
             var identifier = new ContentItemVariantIdentifier(itemIdentifier, variantIdentifier);
             var actualUrl = _builder.BuildVariantsUrl(identifier);
-            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{ITEM_EXTERNAL_ID}/variants/{VARIANT_ID}";
+            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{EXPECTED_ITEM_EXTERNAL_ID}/variants/{VARIANT_ID}";
 
             Assert.Equal(expectedUrl, actualUrl);
         }
@@ -122,7 +123,7 @@ namespace KenticoCloud.ContentManagement.Tests
             var variantIdentifier = LanguageIdentifier.ByCodename(VARIANT_CODENAME);
             var identifier = new ContentItemVariantIdentifier(itemIdentifier, variantIdentifier);
             var actualUrl = _builder.BuildVariantsUrl(identifier);
-            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{ITEM_EXTERNAL_ID}/variants/codename/{VARIANT_CODENAME}";
+            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{EXPECTED_ITEM_EXTERNAL_ID}/variants/codename/{VARIANT_CODENAME}";
 
             Assert.Equal(expectedUrl, actualUrl);
         }
@@ -169,7 +170,7 @@ namespace KenticoCloud.ContentManagement.Tests
         {
             var identifier = ContentItemIdentifier.ByExternalId(ITEM_EXTERNAL_ID);
             var actualUrl = _builder.BuildItemUrl(identifier);
-            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{ITEM_EXTERNAL_ID}";
+            var expectedUrl = $"{ENDPOINT}/projects/{PROJECT_ID}/items/external-id/{EXPECTED_ITEM_EXTERNAL_ID}";
 
             Assert.Equal(expectedUrl, actualUrl);
         }

--- a/KenticoCloud.ContentManagement/ContentManagementEndpointUrlBuilder.cs
+++ b/KenticoCloud.ContentManagement/ContentManagementEndpointUrlBuilder.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Net;
 using KenticoCloud.ContentManagement.Models.Items;
 using KenticoCloud.ContentManagement.Models.Assets;
 
@@ -93,10 +93,15 @@ namespace KenticoCloud.ContentManagement
 
             if (!string.IsNullOrEmpty(identifier.ExternalId))
             {
-                return string.Format(URL_TEMPLATE_ITEM_EXTERNAL_ID, identifier.ExternalId);
+                return BuildItemUrlSegmentFromExternalId(identifier.ExternalId);
             }
-
             throw new ArgumentException("You must provide item's id, codename or externalId");
+        }
+
+        internal string BuildItemUrlSegmentFromExternalId(string externalId)
+        {
+            var escapedExternalId = WebUtility.UrlEncode(externalId);
+            return string.Format(URL_TEMPLATE_ITEM_EXTERNAL_ID, escapedExternalId);
         }
 
         #endregion
@@ -130,7 +135,8 @@ namespace KenticoCloud.ContentManagement
 
         public string BuildAssetsUrlFromExternalId(string externalId)
         {
-            return GetUrl(string.Format(URL_TEMPLATE_ASSET_EXTERNAL_ID, externalId));
+            var escapedExternalId = WebUtility.UrlEncode(externalId);
+            return GetUrl(string.Format(URL_TEMPLATE_ASSET_EXTERNAL_ID, escapedExternalId));
         }
 
         #endregion


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #27 

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

- By calling the controller, verify that a content item and asset with a slash in the external ID is really created/updated.
- Create a content item via rest API using external id with a slash, then try to update the same content item via the controller, using the same external id