### PR TITLE
KCL-2816 - add a binary file url to the asset response model

### DIFF
--- a/KenticoCloud.ContentManagement.Tests/ContentManagementClientTests.cs
+++ b/KenticoCloud.ContentManagement.Tests/ContentManagementClientTests.cs
@@ -990,6 +990,7 @@ namespace KenticoCloud.ContentManagement.Tests
                 Assert.NotNull(assetResult.LastModified);
                 Assert.Equal(fileName, assetResult.FileName);
                 Assert.NotNull(assetResult.Descriptions);
+                Assert.NotNull(assetResult.Url);
 
                 // Cleanup
                 await client.DeleteAssetAsync(AssetIdentifier.ById(assetResult.Id));
@@ -1037,6 +1038,7 @@ namespace KenticoCloud.ContentManagement.Tests
             Assert.NotNull(assetResult.LastModified);
             Assert.Equal(fileName, assetResult.FileName);
             Assert.Equal(spanishDescription, assetResult.Descriptions.FirstOrDefault(d => d.Language.Id == EXISTING_LANGUAGE_ID).Description);
+            Assert.NotNull(assetResult.Url);
 
             // Cleanup
             await client.DeleteAssetAsync(AssetIdentifier.ByExternalId(externalId));
@@ -1069,6 +1071,7 @@ namespace KenticoCloud.ContentManagement.Tests
             Assert.Equal(fileName, assetResult.FileName);
             Assert.Equal(title, assetResult.Title);
             Assert.Equal(spanishDescription, assetResult.Descriptions.FirstOrDefault(d => d.Language.Id == EXISTING_LANGUAGE_ID).Description);
+            Assert.NotNull(assetResult.Url);
 
             // Cleanup
             await client.DeleteAssetAsync(AssetIdentifier.ById(assetResult.Id));
@@ -1096,6 +1099,7 @@ namespace KenticoCloud.ContentManagement.Tests
             Assert.Equal("kentico_rgb_bigger.png", assetResult.FileName);
             Assert.NotNull(assetResult.Descriptions);
             Assert.Equal(title, assetResult.Title);
+            Assert.NotNull(assetResult.Url);
 
             // Cleanup
             await client.DeleteAssetAsync(AssetIdentifier.ById(assetResult.Id));
@@ -1130,6 +1134,7 @@ namespace KenticoCloud.ContentManagement.Tests
             Assert.Equal(fileName, assetResult.FileName);
             Assert.Equal(title, assetResult.Title);
             Assert.Equal(spanishDescription, assetResult.Descriptions.FirstOrDefault(d => d.Language.Id == EXISTING_LANGUAGE_ID).Description);
+            Assert.NotNull(assetResult.Url);
 
             // Cleanup
             await client.DeleteAssetAsync(AssetIdentifier.ByExternalId(externalId));

--- a/KenticoCloud.ContentManagement.Tests/Data/CreateAsset_3NJwu6QYJN/POST_2cOMZAbM8a/response_content.json
+++ b/KenticoCloud.ContentManagement.Tests/Data/CreateAsset_3NJwu6QYJN/POST_2cOMZAbM8a/response_content.json
@@ -4,6 +4,7 @@
   "title": null,
   "size": 84,
   "type": "text/plain",
+  "url": "https://assets-us-01.kc-usercontent.com/e38f8e94-7d3b-0062-77f5-a4bc505780d4/9a8c094f-2dc4-4741-9c95-4de03f597e4b/Hello.txt",
   "image_width": null,
   "image_height": null,
   "file_reference": {
@@ -24,5 +25,5 @@
       "description": null
     }
   ],
-  "last_modified": "2019-01-10T13:30:39.6702216Z"
+  "last_modified": "2019-10-03T10:35:18.5327648Z"
 }

--- a/KenticoCloud.ContentManagement.Tests/Data/CreateAsset_Vmhhwfhm5l/POST_s_isjmStHn/response_content.json
+++ b/KenticoCloud.ContentManagement.Tests/Data/CreateAsset_Vmhhwfhm5l/POST_s_isjmStHn/response_content.json
@@ -4,6 +4,7 @@
   "title": "My new asset",
   "size": 5719,
   "type": "image/png",
+  "url": "https://assets-us-01.kc-usercontent.com/e38f8e94-7d3b-0062-77f5-a4bc505780d4/4510bf46-4deb-4f55-abcd-40d715e52f32/kentico_rgb_bigger.png",
   "image_width": 550,
   "image_height": 250,
   "file_reference": {
@@ -24,5 +25,5 @@
       "description": null
     }
   ],
-  "last_modified": "2019-01-10T13:30:56.3158639Z"
+  "last_modified": "2019-10-03T10:35:18.5327648Z"
 }

--- a/KenticoCloud.ContentManagement.Tests/Data/CreateAsset__KW1FA4lVJ/POST_AGis8GuB6r/response_content.json
+++ b/KenticoCloud.ContentManagement.Tests/Data/CreateAsset__KW1FA4lVJ/POST_AGis8GuB6r/response_content.json
@@ -4,6 +4,7 @@
   "title": "New title",
   "size": 82,
   "type": "text/plain",
+  "url": "https://assets-us-01.kc-usercontent.com/e38f8e94-7d3b-0062-77f5-a4bc505780d4/a57a09bf-d1f9-42e6-a2d3-4d75016bb892/Hello.txt",
   "image_width": null,
   "image_height": null,
   "file_reference": {
@@ -24,5 +25,5 @@
       "description": "Spanish descriptión"
     }
   ],
-  "last_modified": "2019-01-10T13:31:17.5433775Z"
+  "last_modified": "2019-10-03T10:35:18.5327648Z"
 }

--- a/KenticoCloud.ContentManagement.Tests/Data/UpsertAssetByExternalId_DuRHOxHJmO/PUT_bYTQwEJQv1/response_content.json
+++ b/KenticoCloud.ContentManagement.Tests/Data/UpsertAssetByExternalId_DuRHOxHJmO/PUT_bYTQwEJQv1/response_content.json
@@ -4,6 +4,7 @@
   "title": "New title",
   "size": 99,
   "type": "text/plain",
+  "url": "https://assets-us-01.kc-usercontent.com/e38f8e94-7d3b-0062-77f5-a4bc505780d4/d4205149-3b94-446e-8e35-8b4aad314169/HelloExternal.txt",
   "image_width": null,
   "image_height": null,
   "file_reference": {
@@ -25,5 +26,5 @@
     }
   ],
   "external_id": "5bec7f21ad2e44bb8a3a1f4a6a5bf8ca",
-  "last_modified": "2019-01-10T13:30:47.5460963Z"
+  "last_modified": "2019-10-03T10:35:18.5327648Z"
 }

--- a/KenticoCloud.ContentManagement.Tests/Data/UpsertAssetByExternalId_ThZdnYABq8/PUT_FyOVYVdXZL/response_content.json
+++ b/KenticoCloud.ContentManagement.Tests/Data/UpsertAssetByExternalId_ThZdnYABq8/PUT_FyOVYVdXZL/response_content.json
@@ -4,6 +4,7 @@
   "title": null,
   "size": 99,
   "type": "text/plain",
+  "url": "https://assets-us-01.kc-usercontent.com/e38f8e94-7d3b-0062-77f5-a4bc505780d4/d9c16ed8-89a0-4324-abfa-4c09dfa96db9/HelloExternal.txt",
   "image_width": null,
   "image_height": null,
   "file_reference": {
@@ -25,5 +26,5 @@
     }
   ],
   "external_id": "99877608d1f6448ebb35778f027c92f6",
-  "last_modified": "2019-01-10T13:30:38.6389409Z"
+  "last_modified": "2019-10-03T10:35:18.5327648Z"
 }

--- a/KenticoCloud.ContentManagement/Models/Assets/AssetModel.cs
+++ b/KenticoCloud.ContentManagement/Models/Assets/AssetModel.cs
@@ -35,6 +35,12 @@ namespace KenticoCloud.ContentManagement.Models.Assets
         public string Type { get; set; }
 
         /// <summary>
+        /// Gets or sets the url to access the asset binary file.
+        /// </summary>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        /// <summary>
         /// Gets or sets the file reference of the the asset".
         /// </summary>
         [JsonProperty("file_reference")]


### PR DESCRIPTION
### Motivation

Return the new property (binary file URL) that was added to the asset response model.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Try to list/get/create/update an asset, the returned model should contain the correct asset URL.